### PR TITLE
Added Python 3.4.4 for the Windows version.

### DIFF
--- a/windows/py3/Dockerfile
+++ b/windows/py3/Dockerfile
@@ -1,0 +1,52 @@
+FROM ubuntu:14.04
+
+ENV DEBIAN_FRONTEND noninteractive
+
+ARG WINE_VERSION=winehq-devel
+ARG PYTHON_VERSION=3.4.4
+ARG PYINSTALLER_VERSION=3.2
+
+# we need wine for this all to work, so we'll use the PPA
+RUN set -x \
+    && dpkg --add-architecture i386 \
+    && apt-get update -qy \
+    && apt-get install --no-install-recommends -qfy software-properties-common \
+    && add-apt-repository ppa:wine/wine-builds \
+    && apt-get update -qy \
+    && apt-get install --no-install-recommends -qfy $WINE_VERSION winetricks wget \
+    && apt-get clean
+
+# wine settings
+ENV WINEARCH win32
+ENV WINEDEBUG fixme-all
+ENV WINEPREFIX /wine
+
+# install python inside wine
+RUN set -x \
+    && wget -nv https://www.python.org/ftp/python/$PYTHON_VERSION/python-$PYTHON_VERSION.msi \
+    && wine msiexec /qn /a python-$PYTHON_VERSION.msi \
+    && rm python-$PYTHON_VERSION.msi \
+    && sed -i 's/_windows_cert_stores = .*/_windows_cert_stores = ("ROOT",)/' "/wine/drive_c/Python34/Lib/ssl.py" \
+    && echo 'wine '\''C:\Python34\python.exe'\'' "$@"' > /usr/bin/python \
+    && echo 'wine '\''C:\Python34\Scripts\easy_install.exe'\'' "$@"' > /usr/bin/easy_install \
+    && echo 'wine '\''C:\Python34\Scripts\pip.exe'\'' "$@"' > /usr/bin/pip \
+    && echo 'wine '\''C:\Python34\Scripts\pyinstaller.exe'\'' "$@"' > /usr/bin/pyinstaller \
+    && chmod +x /usr/bin/* \
+    && wget https://bootstrap.pypa.io/ez_setup.py -O - | /usr/bin/python \
+    && (pip install -U pip || true) \
+    && echo 'assoc .py=PythonScript' | wine cmd \
+    && echo 'ftype PythonScript=c:\Python34\python.exe "%1" %*' | wine cmd \
+    && while pgrep wineserver >/dev/null; do echo "Waiting for wineserver"; sleep 1; done \
+    && rm -rf /tmp/.wine-*
+
+# install pyinstaller
+RUN /usr/bin/pip install pyinstaller==$PYINSTALLER_VERSION
+
+# put the src folder inside wine
+RUN mkdir /src/ && ln -s /src /wine/drive_c/src
+VOLUME /src/
+WORKDIR /wine/drive_c/src/
+RUN mkdir -p /wine/drive_c/tmp
+
+CMD pip install -r requirements.txt && pyinstaller --clean -y --dist ./dist/windows --workpath /tmp *.spec
+


### PR DESCRIPTION
As the title says, this is a working version of Python 3.4, since that still has MSI support, and can be installed headless.

The upgrade of pip from pip works, except that pip fails to delete some temp files, so we ignore the result.

The rest it's pretty much your 2.7 Dockerfile.