### PR TITLE
Custom pypi URL, pyinstaller options, optional requirements.txt

### DIFF
--- a/linux/py2/Dockerfile
+++ b/linux/py2/Dockerfile
@@ -17,4 +17,6 @@ RUN mkdir /src/
 VOLUME /src/
 WORKDIR /src/
 
-CMD pip install -r requirements.txt && pyinstaller --clean -y --dist ./dist/linux --workpath /tmp *.spec
+ENTRYPOINT if [ -f requirements.txt ]; then pip install -r requirements.txt; fi && pyinstaller
+CMD ["--clean", "-y" ,"--dist" ,"./dist/linux", "--workpath", "/tmp" , "*.spec"]
+

--- a/linux/py2/Dockerfile
+++ b/linux/py2/Dockerfile
@@ -10,6 +10,12 @@ RUN set -x \
     && apt-get install --no-install-recommends -qfy python python-dev python-pip python-setuptools build-essential libmysqlclient-dev \
     && apt-get clean
 
+# PYPI repository location
+ENV PYPI_URL=https://pypi.python.org/
+# PYPI index location
+ENV PYPI_INDEX_URL=https://pypi.python.org/simple
+
+
 # install pyinstaller
 RUN pip install pyinstaller==$PYINSTALLER_VERSION
 
@@ -17,6 +23,8 @@ RUN mkdir /src/
 VOLUME /src/
 WORKDIR /src/
 
-ENTRYPOINT if [ -f requirements.txt ]; then pip install -r requirements.txt; fi && pyinstaller
-CMD ["--clean", "-y" ,"--dist" ,"./dist/linux", "--workpath", "/tmp" , "*.spec"]
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]
 

--- a/linux/py2/entrypoint.sh
+++ b/linux/py2/entrypoint.sh
@@ -12,7 +12,7 @@ if [[ "$PYPI_URL" != "https://pypi.python.org/" ]] || \
     # the funky looking regexp just extracts the hostname, excluding port
     # to be used as a trusted-host.
     mkdir -p /root/pip
-    echo "[global]" > /pip/pip.conf
+    echo "[global]" > /root/pip/pip.conf
     echo "index = $PYPI_URL" >> /root/pip/pip.conf
     echo "index-url = $PYPI_INDEX_URL" >> /root/pip/pip.conf
     echo "trusted-host = $(echo $PYPI_URL | perl -pe 's|^.*?://(.*?)(:.*?)?/.*$|$1|')" >> /root/pip/pip.conf

--- a/linux/py2/entrypoint.sh
+++ b/linux/py2/entrypoint.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# Fail on errors.
+set -e
+
+#
+# In case the user specified a custom URL for PYPI, then use
+# that one, instead of the default one.
+#
+if [[ "$PYPI_URL" != "https://pypi.python.org/" ]] || \
+   [[ "$PYPI_INDEX_URL" != "https://pypi.python.org/simple" ]]; then
+    # the funky looking regexp just extracts the hostname, excluding port
+    # to be used as a trusted-host.
+    mkdir -p /root/pip
+    echo "[global]" > /pip/pip.conf
+    echo "index = $PYPI_URL" >> /root/pip/pip.conf
+    echo "index-url = $PYPI_INDEX_URL" >> /root/pip/pip.conf
+    echo "trusted-host = $(echo $PYPI_URL | perl -pe 's|^.*?://(.*?)(:.*?)?/.*$|$1|')" >> /root/pip/pip.conf
+
+    echo "Using custom pip.conf: "
+    cat /root/pip/pip.conf
+fi
+
+cd /src
+
+if [ -f requirements.txt ]; then
+    pip install -r requirements.txt
+fi # [ -f requirements.txt ]
+
+echo "$@"
+
+if [[ "$@" == "" ]]; then
+    pyinstaller --clean -y --dist ./dist/linux --workpath /tmp *.spec
+else
+    $@
+fi # [[ "$@" == "" ]]
+

--- a/linux/py3/Dockerfile
+++ b/linux/py3/Dockerfile
@@ -18,4 +18,6 @@ RUN mkdir /src/
 VOLUME /src/
 WORKDIR /src/
 
-CMD pip install -r requirements.txt && pyinstaller --clean -y --dist ./dist/linux --workpath /tmp *.spec
+ENTRYPOINT if [ -f requirements.txt ]; then pip install -r requirements.txt; fi && pyinstaller
+CMD ["--clean", "-y" ,"--dist" ,"./dist/linux", "--workpath", "/tmp" , "*.spec"]
+

--- a/linux/py3/Dockerfile
+++ b/linux/py3/Dockerfile
@@ -18,6 +18,8 @@ RUN mkdir /src/
 VOLUME /src/
 WORKDIR /src/
 
-ENTRYPOINT if [ -f requirements.txt ]; then pip install -r requirements.txt; fi && pyinstaller
-CMD ["--clean", "-y" ,"--dist" ,"./dist/linux", "--workpath", "/tmp" , "*.spec"]
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]
 

--- a/linux/py3/entrypoint.sh
+++ b/linux/py3/entrypoint.sh
@@ -12,7 +12,7 @@ if [[ "$PYPI_URL" != "https://pypi.python.org/" ]] || \
     # the funky looking regexp just extracts the hostname, excluding port
     # to be used as a trusted-host.
     mkdir -p /root/pip
-    echo "[global]" > /pip/pip.conf
+    echo "[global]" > /root/pip/pip.conf
     echo "index = $PYPI_URL" >> /root/pip/pip.conf
     echo "index-url = $PYPI_INDEX_URL" >> /root/pip/pip.conf
     echo "trusted-host = $(echo $PYPI_URL | perl -pe 's|^.*?://(.*?)(:.*?)?/.*$|$1|')" >> /root/pip/pip.conf

--- a/linux/py3/entrypoint.sh
+++ b/linux/py3/entrypoint.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# Fail on errors.
+set -e
+
+#
+# In case the user specified a custom URL for PYPI, then use
+# that one, instead of the default one.
+#
+if [[ "$PYPI_URL" != "https://pypi.python.org/" ]] || \
+   [[ "$PYPI_INDEX_URL" != "https://pypi.python.org/simple" ]]; then
+    # the funky looking regexp just extracts the hostname, excluding port
+    # to be used as a trusted-host.
+    mkdir -p /root/pip
+    echo "[global]" > /pip/pip.conf
+    echo "index = $PYPI_URL" >> /root/pip/pip.conf
+    echo "index-url = $PYPI_INDEX_URL" >> /root/pip/pip.conf
+    echo "trusted-host = $(echo $PYPI_URL | perl -pe 's|^.*?://(.*?)(:.*?)?/.*$|$1|')" >> /root/pip/pip.conf
+
+    echo "Using custom pip.conf: "
+    cat /root/pip/pip.conf
+fi
+
+cd /src
+
+if [ -f requirements.txt ]; then
+    pip install -r requirements.txt
+fi # [ -f requirements.txt ]
+
+echo "$@"
+
+if [[ "$@" == "" ]]; then
+    pyinstaller --clean -y --dist ./dist/linux --workpath /tmp *.spec
+else
+    $@
+fi # [[ "$@" == "" ]]
+

--- a/windows/py2/Dockerfile
+++ b/windows/py2/Dockerfile
@@ -21,6 +21,11 @@ ENV WINEARCH win32
 ENV WINEDEBUG fixme-all
 ENV WINEPREFIX /wine
 
+# PYPI repository location
+ENV PYPI_URL=https://pypi.python.org/
+# PYPI index location
+ENV PYPI_INDEX_URL=https://pypi.python.org/simple
+
 # install python inside wine
 RUN set -x \
     && wget -nv https://www.python.org/ftp/python/$PYTHON_VERSION/python-$PYTHON_VERSION.msi \
@@ -48,6 +53,8 @@ VOLUME /src/
 WORKDIR /wine/drive_c/src/
 RUN mkdir -p /wine/drive_c/tmp
 
-ENTRYPOINT if [ -f requirements.txt ]; then pip install -r requirements.txt; fi && pyinstaller
-CMD ["--clean", "-y" ,"--dist" ,"./dist/windows", "--workpath", "/tmp" , "*.spec"]
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]
 

--- a/windows/py2/Dockerfile
+++ b/windows/py2/Dockerfile
@@ -48,4 +48,6 @@ VOLUME /src/
 WORKDIR /wine/drive_c/src/
 RUN mkdir -p /wine/drive_c/tmp
 
-CMD pip install -r requirements.txt && pyinstaller --clean -y --dist ./dist/windows --workpath /tmp *.spec
+ENTRYPOINT if [ -f requirements.txt ]; then pip install -r requirements.txt; fi && pyinstaller
+CMD ["--clean", "-y" ,"--dist" ,"./dist/windows", "--workpath", "/tmp" , "*.spec"]
+

--- a/windows/py2/entrypoint.sh
+++ b/windows/py2/entrypoint.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# Fail on errors.
+set -e
+
+#
+# In case the user specified a custom URL for PYPI, then use
+# that one, instead of the default one.
+#
+if [[ "$PYPI_URL" != "https://pypi.python.org/" ]] || \
+   [[ "$PYPI_INDEX_URL" != "https://pypi.python.org/simple" ]]; then
+    # the funky looking regexp just extracts the hostname, excluding port
+    # to be used as a trusted-host.
+    mkdir -p /wine/drive_c/users/root/pip
+    echo "[global]" > /wine/drive_c/users/root/pip/pip.ini
+    echo "index = $PYPI_URL" >> /wine/drive_c/users/root/pip/pip.ini
+    echo "index-url = $PYPI_INDEX_URL" >> /wine/drive_c/users/root/pip/pip.ini
+    echo "trusted-host = $(echo $PYPI_URL | perl -pe 's|^.*?://(.*?)(:.*?)?/.*$|$1|')" >> /wine/drive_c/users/root/pip/pip.ini
+
+    echo "Using custom pip.ini: "
+    cat /wine/drive_c/users/root/pip/pip.ini
+fi
+
+cd /src
+
+if [ -f requirements.txt ]; then
+    pip install -r requirements.txt
+fi # [ -f requirements.txt ]
+
+echo "$@"
+
+if [[ "$@" == "" ]]; then
+    pyinstaller --clean -y --dist ./dist/windows --workpath /tmp *.spec
+else
+    $@
+fi # [[ "$@" == "" ]]
+

--- a/windows/py3/Dockerfile
+++ b/windows/py3/Dockerfile
@@ -51,5 +51,6 @@ VOLUME /src/
 WORKDIR /wine/drive_c/src/
 RUN mkdir -p /wine/drive_c/tmp
 
-CMD pip install -r requirements.txt && pyinstaller --clean -y --dist ./dist/windows --workpath /tmp *.spec
+ENTRYPOINT if [ -f requirements.txt ]; then pip install -r requirements.txt; fi &&
+CMD ["pyinstaller", "--clean", "-y" ,"--dist" ,"./dist/windows", "--workpath", "/tmp" , "*.spec"]
 

--- a/windows/py3/Dockerfile
+++ b/windows/py3/Dockerfile
@@ -21,6 +21,19 @@ ENV WINEARCH win32
 ENV WINEDEBUG fixme-all
 ENV WINEPREFIX /wine
 
+# PYPI repository location
+ARG pypi_url=https://pypi.python.org/
+# PYPI index location
+ARG pypi_index_url=https://pypi.python.org/simple
+
+# the funky looking regexp just extracts the hostname, excluding port
+# to be used as a trusted-host.
+RUN mkdir -p /wine/drive_c/users/root/pip && \
+    echo "[global]" > /wine/drive_c/users/root/pip/pip.ini && \
+    echo "index = $pypi_url" >> /wine/drive_c/users/root/pip/pip.ini && \
+    echo "index-url = $pypi_index_url" >> /wine/drive_c/users/root/pip/pip.ini && \
+    echo "trusted-host = $(echo $pypi_url | perl -pe 's|^.*?://(.*?)(:.*?)?/.*$|$1|')" >> /wine/drive_c/users/root/pip/pip.ini
+
 # install python in wine, using the msi packages to install, extracting
 # the files directly, since installing isn't running correctly.
 RUN set -x \

--- a/windows/py3/Dockerfile
+++ b/windows/py3/Dockerfile
@@ -51,6 +51,8 @@ VOLUME /src/
 WORKDIR /wine/drive_c/src/
 RUN mkdir -p /wine/drive_c/tmp
 
-ENTRYPOINT if [ -f requirements.txt ]; then pip install -r requirements.txt; fi &&
-CMD ["pyinstaller", "--clean", "-y" ,"--dist" ,"./dist/windows", "--workpath", "/tmp" , "*.spec"]
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]
 

--- a/windows/py3/entrypoint.sh
+++ b/windows/py3/entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+cd /src
+
+if [ -f requirements.txt ]; then
+    pip install -r requirements.txt
+fi # [ -f requirements.txt ]
+
+echo "$@"
+
+if [[ "$@" == "" ]]; then
+    pyinstaller --clean -y --dist ./dist/windows --workpath /tmp *.spec
+else
+    $@
+fi # [[ "$@" == "" ]]
+


### PR DESCRIPTION
Implemented fixes for #3, #4, and #5.
#5- is required for build systems.
#3, and #4 are good for quick demos, to show off the functionality of pyinstaller.

This fix keeps compatibility with the previous usage. The last thing that I would implement is running under a custom UID/GID.

To run with the custom pypi, someone can for example:

```
DOCKER_IMAGE="cdrx/pyinstaller-windows:python2"

docker run -it \
    --rm \
    -v $(readlink -f $(dirname $(readlink -f "$0"))/..):/src \
    --link nexus \
    -e PYPI_URL="http://nexus:8081/repository/pypi-local/pyp" \
    -e PYPI_INDEX_URL="http://nexus:8081/repository/pypi-local/simple" \
    $DOCKER_IMAGE
```