### PR TITLE
Fixed bug with concatenated commands in entrypoint.sh arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ will build your PyInstaller project into `dist/linux/`. The binary will have the
 You'll need to supply a custom command to Docker to install system pacakges. Something like:
 
 ```
-docker run -v "$(pwd):/src/" cdrx/pyinstaller-linux sh -c "apt-get update -y && apt-get install -y wget && pip install -r requirements.txt && pyinstaller --clean -y --dist ./dist/linux --workpath /tmp *.spec"
+docker run -v "$(pwd):/src/" cdrx/pyinstaller-linux "apt-get update -y && apt-get install -y wget && pip install -r requirements.txt && pyinstaller --clean -y --dist ./dist/linux --workpath /tmp *.spec"
 ```
 
 Replace `wget` with the dependencies / package(s) you need to install.

--- a/linux/py2/entrypoint.sh
+++ b/linux/py2/entrypoint.sh
@@ -32,6 +32,6 @@ echo "$@"
 if [[ "$@" == "" ]]; then
     pyinstaller --clean -y --dist ./dist/linux --workpath /tmp *.spec
 else
-    $@
+    sh -c "$@"
 fi # [[ "$@" == "" ]]
 

--- a/linux/py3/entrypoint.sh
+++ b/linux/py3/entrypoint.sh
@@ -32,6 +32,6 @@ echo "$@"
 if [[ "$@" == "" ]]; then
     pyinstaller --clean -y --dist ./dist/linux --workpath /tmp *.spec
 else
-    $@
+    sh -c "$@"
 fi # [[ "$@" == "" ]]
 

--- a/windows/py2/entrypoint.sh
+++ b/windows/py2/entrypoint.sh
@@ -32,6 +32,6 @@ echo "$@"
 if [[ "$@" == "" ]]; then
     pyinstaller --clean -y --dist ./dist/windows --workpath /tmp *.spec
 else
-    $@
+    sh -c "$@"
 fi # [[ "$@" == "" ]]
 

--- a/windows/py3/entrypoint.sh
+++ b/windows/py3/entrypoint.sh
@@ -32,5 +32,5 @@ echo "$@"
 if [[ "$@" == "" ]]; then
     pyinstaller --clean -y --dist ./dist/windows --workpath /tmp *.spec
 else
-    $@
+    sh -c "$@"
 fi # [[ "$@" == "" ]]


### PR DESCRIPTION
If you use the arguments
`... sh -c "a && b"`
`$@` in entrypoint.sh will resolve to:
`sh -c a "&&" b`
so instead of executing b after a, "&&" and b are just additional arguments for sh.
Furthermore the former syntax would work, if the arguments for sh don't have any space:
`... sh -c "a&&b"`
in this case `$@` is what you want:
`sh  -c "a&&b"`
