### PR TITLE
Change the file owner after the run.

### DIFF
--- a/linux/py2/Dockerfile
+++ b/linux/py2/Dockerfile
@@ -15,6 +15,9 @@ ENV PYPI_URL=https://pypi.python.org/
 # PYPI index location
 ENV PYPI_INDEX_URL=https://pypi.python.org/simple
 
+# CHOWN flags
+ENV PYINSTALLER_CHOWN=""
+
 
 # install pyinstaller
 RUN pip install pyinstaller==$PYINSTALLER_VERSION

--- a/linux/py2/entrypoint.sh
+++ b/linux/py2/entrypoint.sh
@@ -35,3 +35,7 @@ else
     sh -c "$@"
 fi # [[ "$@" == "" ]]
 
+if [[ "$PYINSTALLER_CHOWN" != "" ]]; then
+    chown -R $PYINSTALLER_CHOWN /src/dist/
+fi # [[ "$PYINSTALLER_CHOWN" != "" ]]
+

--- a/linux/py3/Dockerfile
+++ b/linux/py3/Dockerfile
@@ -15,6 +15,9 @@ ENV PYPI_URL=https://pypi.python.org/
 # PYPI index location
 ENV PYPI_INDEX_URL=https://pypi.python.org/simple
 
+# CHOWN flags
+ENV PYINSTALLER_CHOWN=""
+
 # install pyinstaller
 RUN pip3 install pyinstaller==$PYINSTALLER_VERSION
 RUN ln -s /usr/bin/pip3 /usr/bin/pip

--- a/linux/py3/entrypoint.sh
+++ b/linux/py3/entrypoint.sh
@@ -35,3 +35,7 @@ else
     sh -c "$@"
 fi # [[ "$@" == "" ]]
 
+if [[ "$PYINSTALLER_CHOWN" != "" ]]; then
+    chown -R $PYINSTALLER_CHOWN /src/dist/
+fi # [[ "$PYINSTALLER_CHOWN" != "" ]]
+

--- a/windows/py2/Dockerfile
+++ b/windows/py2/Dockerfile
@@ -26,11 +26,14 @@ ENV PYPI_URL=https://pypi.python.org/
 # PYPI index location
 ENV PYPI_INDEX_URL=https://pypi.python.org/simple
 
+# CHOWN flags
+ENV PYINSTALLER_CHOWN=""
+
 # install python inside wine
 RUN set -x \
     && wget -nv https://www.python.org/ftp/python/$PYTHON_VERSION/python-$PYTHON_VERSION.msi \
     && wine msiexec /qn /a python-$PYTHON_VERSION.msi \
-    && rm python-2.7.12.msi \
+    && rm python-$PYTHON_VERSION.msi \
     && sed -i 's/_windows_cert_stores = .*/_windows_cert_stores = ("ROOT",)/' "/wine/drive_c/Python27/Lib/ssl.py" \
     && echo 'wine '\''C:\Python27\python.exe'\'' "$@"' > /usr/bin/python \
     && echo 'wine '\''C:\Python27\Scripts\easy_install.exe'\'' "$@"' > /usr/bin/easy_install \

--- a/windows/py2/entrypoint.sh
+++ b/windows/py2/entrypoint.sh
@@ -35,3 +35,7 @@ else
     sh -c "$@"
 fi # [[ "$@" == "" ]]
 
+if [[ "$PYINSTALLER_CHOWN" != "" ]]; then
+    chown -R $PYINSTALLER_CHOWN /src/dist/
+fi # [[ "$PYINSTALLER_CHOWN" != "" ]]
+

--- a/windows/py3/Dockerfile
+++ b/windows/py3/Dockerfile
@@ -26,6 +26,9 @@ ENV PYPI_URL=https://pypi.python.org/
 # PYPI index location
 ENV PYPI_INDEX_URL=https://pypi.python.org/simple
 
+# CHOWN flags
+ENV PYINSTALLER_CHOWN=""
+
 # install python in wine, using the msi packages to install, extracting
 # the files directly, since installing isn't running correctly.
 RUN set -x \

--- a/windows/py3/entrypoint.sh
+++ b/windows/py3/entrypoint.sh
@@ -34,3 +34,8 @@ if [[ "$@" == "" ]]; then
 else
     sh -c "$@"
 fi # [[ "$@" == "" ]]
+
+if [[ "$PYINSTALLER_CHOWN" != "" ]]; then
+    chown -R $PYINSTALLER_CHOWN /src/dist/
+fi # [[ "$PYINSTALLER_CHOWN" != "" ]]
+


### PR DESCRIPTION
Allow specifying the user to `chown`. To be honest, I developed this after the chown fix from Dustin Spicuzza.

I have a script like this: 

```sh
#!/usr/bin/env bash

DOCKER_IMAGE="cdrx/pyinstaller-windows:python2"

docker run -it \
    --rm \
    -v $(readlink -f $(dirname $(readlink -f "$0"))/..):/src \
    --link nexus \
    -e PYPI_URL="http://nexus:8081/repository/pypi-local/pyp" \
    -e PYPI_INDEX_URL="http://nexus:8081/repository/pypi-local/simple" \
    -e PYINSTALLER_CHOWN="$(id -u):$(id -g)" \
    $DOCKER_IMAGE
```

This actually keeps the user that runs the program.