### PR TITLE
Add install VCForPython27, needed for pyinstaller builds

### DIFF
--- a/win32/py2/Dockerfile
+++ b/win32/py2/Dockerfile
@@ -31,6 +31,9 @@ RUN set -x \
     && wget -nv https://www.python.org/ftp/python/$PYTHON_VERSION/python-$PYTHON_VERSION.msi \
     && wine msiexec /qn /a python-$PYTHON_VERSION.msi \
     && rm python-2.7.12.msi \
+    && wget -nv https://download.microsoft.com/download/7/9/6/796EF2E4-801B-4FC4-AB28-B59FBF6D907B/VCForPython27.msi \
+    && wine msiexec /qn /a VCForPython27.msi \
+    && rm VCForPython27.msi \
     && sed -i 's/_windows_cert_stores = .*/_windows_cert_stores = ("ROOT",)/' "/wine/drive_c/Python27/Lib/ssl.py" \
     && echo 'wine '\''C:\Python27\python.exe'\'' "$@"' > /usr/bin/python \
     && echo 'wine '\''C:\Python27\Scripts\easy_install.exe'\'' "$@"' > /usr/bin/easy_install \


### PR DESCRIPTION
Some builds require VCForPython27