### PR TITLE
Update python version to 3.6.6 for linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Current PyInstaller version used: 3.3.
 
 The `:python2` tags run Python 2.7.
 
-The `:python3` tag runs Python 3.5 on Linux and Python 3.6 on Windows.
+The `:python3` tag runs Python 3.6 on Linux and Python 3.6 on Windows.
 
 ## Usage
 

--- a/linux/py3/Dockerfile
+++ b/linux/py3/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 ENV DEBIAN_FRONTEND noninteractive
 


### PR DESCRIPTION
Changed Dockerfile to ubuntu 18.04 that uses python version 3.6.6.
My local build works great.