### PR TITLE
Use pyenv with an old glibc version 2.15

### DIFF
--- a/linux/py3/Dockerfile
+++ b/linux/py3/Dockerfile
@@ -1,29 +1,41 @@
-FROM ubuntu:18.04
+FROM ubuntu:12.04
+SHELL ["/bin/bash", "-i", "-c"]
 
-ENV DEBIAN_FRONTEND noninteractive
-
-ARG PYINSTALLER_VERSION=3.3
-
-# install python
-RUN set -x \
-    && apt-get update -qy \
-    && apt-get install --no-install-recommends -qfy python3 python3-dev python3-pip python3-setuptools python3-wheel build-essential libmysqlclient-dev git \
-    && apt-get clean
-
-# PYPI repository location
-ENV PYPI_URL=https://pypi.python.org/
-# PYPI index location
-ENV PYPI_INDEX_URL=https://pypi.python.org/simple
-
-# install pyinstaller
-RUN pip3 install pyinstaller==$PYINSTALLER_VERSION
-RUN ln -s /usr/bin/pip3 /usr/bin/pip
-
-RUN mkdir /src/
-VOLUME /src/
-WORKDIR /src/
+ARG PYTHON_VERSION=3.6.6
+ARG PYINSTALLER_VERSION=3.4
 
 COPY entrypoint.sh /entrypoint.sh
-RUN chmod +x /entrypoint.sh
+
+# update system
+RUN apt-get update \
+    # install requirements
+    && apt-get install -y --no-install-recommends \
+        build-essential \
+        ca-certificates \
+        curl \
+        git \
+        libbz2-dev \
+        libreadline-dev \
+        libsqlite3-dev \
+        libssl-dev \
+        zlib1g-dev \
+    # install pyenv
+    && echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc \
+    && echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc \
+    && source ~/.bashrc \
+    && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
+    && echo 'eval "$(pyenv init -)"' >> ~/.bashrc \
+    && source ~/.bashrc \
+    # install python
+    && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install $PYTHON_VERSION \
+    && pyenv global $PYTHON_VERSION \
+    && pip install --upgrade pip \
+    # install pyinstaller
+    && pip install pyinstaller==$PYINSTALLER_VERSION \
+    && mkdir /src/ \
+    && chmod +x /entrypoint.sh
+
+VOLUME /src/
+WORKDIR /src/
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/linux/py3/Dockerfile
+++ b/linux/py3/Dockerfile
@@ -4,10 +4,14 @@ SHELL ["/bin/bash", "-i", "-c"]
 ARG PYTHON_VERSION=3.6.6
 ARG PYINSTALLER_VERSION=3.4
 
+ENV PYPI_URL=https://pypi.python.org/
+ENV PYPI_INDEX_URL=https://pypi.python.org/simple
+
 COPY entrypoint.sh /entrypoint.sh
 
-# update system
-RUN apt-get update \
+RUN \
+    # update system
+    apt-get update \
     # install requirements
     && apt-get install -y --no-install-recommends \
         build-essential \

--- a/linux/py3/Dockerfile
+++ b/linux/py3/Dockerfile
@@ -10,8 +10,9 @@ ENV PYPI_INDEX_URL=https://pypi.python.org/simple
 COPY entrypoint.sh /entrypoint.sh
 
 RUN \
+    set -x \
     # update system
-    apt-get update \
+    && apt-get update \
     # install requirements
     && apt-get install -y --no-install-recommends \
         build-essential \

--- a/linux/py3/entrypoint.sh
+++ b/linux/py3/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -i
 
 # Fail on errors.
 set -e


### PR DESCRIPTION
This Dockerfile uses ubuntu 12.04 with an old glibc version 2.15. But also provides the new Python version 3.6.6 which can be easily changed with the PYTHON_VERSION argument. Until now it's not possible to run executables build with the image for example on ubuntu 16.04 because of the newer glibc version in the docker image.

```
$ docker build -t pyinstaller-linux:python3 .
$ docker run --rm -it pyinstaller-linux:python3 /bin/sh
# python -V
Python 3.6.6
# pyinstaller --version
3.4
# ldd --version
ldd (Ubuntu EGLIBC 2.15-0ubuntu10.18) 2.15
Copyright (C) 2012 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
Written by Roland McGrath and Ulrich Drepper.
```