### PR TITLE
Add PYENV_VERSION environment variable

### DIFF
--- a/linux/py3/Dockerfile
+++ b/linux/py3/Dockerfile
@@ -6,6 +6,7 @@ ARG PYINSTALLER_VERSION=3.4
 
 ENV PYPI_URL=https://pypi.python.org/
 ENV PYPI_INDEX_URL=https://pypi.python.org/simple
+ENV PYENV_VERSION=${PYTHON_VERSION}
 
 COPY entrypoint.sh /entrypoint.sh
 


### PR DESCRIPTION
This fix an issue occuring when loading a src directory containing .python-version file

It simply forces pyenv to use version installed in the container.

Close #50