### PR TITLE
Update README because entrypoint must be overwritten

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ will build your PyInstaller project into `dist/linux/`. The binary will have the
 You'll need to supply a custom command to Docker to install system pacakges. Something like:
 
 ```
-docker run -v "$(pwd):/src/" cdrx/pyinstaller-linux "apt-get update -y && apt-get install -y wget && pip install -r requirements.txt && pyinstaller --clean -y --dist ./dist/linux --workpath /tmp *.spec"
+docker run -v "$(pwd):/src/" --entrypoint /bin/sh cdrx/pyinstaller-linux -c "apt-get update -y && apt-get install -y wget && /entrypoint.sh"
 ```
 
 Replace `wget` with the dependencies / package(s) you need to install.


### PR DESCRIPTION
The docker images specify an ENTRYPOINT and not a CMD.
The ENTRYPOINT is executed before the CMD.
To execute custom command with these docker images the entrypoint has to be set to the shell and then it can execute custom commands before the entrypoint is executed.