### PR TITLE
Forward pyinstaller from 3.4 to 3.5

### DIFF
--- a/linux/py2/Dockerfile
+++ b/linux/py2/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:14.04
 
 ENV DEBIAN_FRONTEND noninteractive
 
-ARG PYINSTALLER_VERSION=3.4
+ARG PYINSTALLER_VERSION=3.5
 
 # install python
 RUN set -x \

--- a/linux/py3/Dockerfile
+++ b/linux/py3/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:12.04
 SHELL ["/bin/bash", "-i", "-c"]
 
 ARG PYTHON_VERSION=3.6.6
-ARG PYINSTALLER_VERSION=3.4
+ARG PYINSTALLER_VERSION=3.5
 
 ENV PYPI_URL=https://pypi.python.org/
 ENV PYPI_INDEX_URL=https://pypi.python.org/simple

--- a/win64/py3/Dockerfile
+++ b/win64/py3/Dockerfile
@@ -4,7 +4,7 @@ ENV DEBIAN_FRONTEND noninteractive
 
 ARG WINE_VERSION=winehq-staging
 ARG PYTHON_VERSION=3.6.4
-ARG PYINSTALLER_VERSION=3.4
+ARG PYINSTALLER_VERSION=3.5
 
 # we need wine for this all to work, so we'll use the PPA
 RUN set -x \


### PR DESCRIPTION
There is a new pyinstaller release:
https://github.com/pyinstaller/pyinstaller/releases/tag/v3.5

As it includes some bugfixes I would like if the version is forwarded.

I've only forwarded the 3.4 version as I don't know, why win32 was left behind with 3.3.