### PR TITLE
Updated py3 variants to use 3.7.5 and pyinstaller 3.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **cdrx/pyinstaller-linux** and **cdrx/pyinstaller-windows** are a pair of Docker containers to ease compiling Python applications to binaries / exe files.
 
-Current PyInstaller version used: 3.5 (for linux and win64), 3.3 (for win32).
+Current PyInstaller version used: 3.5.
 
 ## Tags
 
@@ -10,7 +10,7 @@ Current PyInstaller version used: 3.5 (for linux and win64), 3.3 (for win32).
 
 The `:python2` tags run Python 2.7.
 
-The `:python3` tag runs Python 3.6 on Linux and Python 3.6 on Windows.
+The `:python3` tag runs Python 3.7 on Linux and Python 3.7 on Windows.
 
 ## Usage
 

--- a/linux/py3/Dockerfile
+++ b/linux/py3/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:12.04
 SHELL ["/bin/bash", "-i", "-c"]
 
-ARG PYTHON_VERSION=3.6.6
+ARG PYTHON_VERSION=3.7.5
 ARG PYINSTALLER_VERSION=3.5
 
 ENV PYPI_URL=https://pypi.python.org/

--- a/win32/py3/Dockerfile
+++ b/win32/py3/Dockerfile
@@ -3,8 +3,8 @@ FROM ubuntu:16.04
 ENV DEBIAN_FRONTEND noninteractive
 
 ARG WINE_VERSION=winehq-staging
-ARG PYTHON_VERSION=3.6.4
-ARG PYINSTALLER_VERSION=3.3
+ARG PYTHON_VERSION=3.7.5
+ARG PYINSTALLER_VERSION=3.5
 
 # we need wine for this all to work, so we'll use the PPA
 RUN set -x \
@@ -37,17 +37,17 @@ RUN set -x \
     && winetricks win7 \
     && for msifile in `echo core dev exe lib path pip tcltk tools`; do \
         wget -nv "https://www.python.org/ftp/python/$PYTHON_VERSION/win32/${msifile}.msi"; \
-        wine msiexec /i "${msifile}.msi" /qb TARGETDIR=C:/Python36; \
+        wine msiexec /i "${msifile}.msi" /qb TARGETDIR=C:/Python37; \
         rm ${msifile}.msi; \
     done \
-    && cd /wine/drive_c/Python36 \
-    && echo 'wine '\''C:\Python36\python.exe'\'' "$@"' > /usr/bin/python \
-    && echo 'wine '\''C:\Python36\Scripts\easy_install.exe'\'' "$@"' > /usr/bin/easy_install \
-    && echo 'wine '\''C:\Python36\Scripts\pip.exe'\'' "$@"' > /usr/bin/pip \
-    && echo 'wine '\''C:\Python36\Scripts\pyinstaller.exe'\'' "$@"' > /usr/bin/pyinstaller \
-    && echo 'wine '\''C:\Python36\Scripts\pyupdater.exe'\'' "$@"' > /usr/bin/pyupdater \
+    && cd /wine/drive_c/Python37 \
+    && echo 'wine '\''C:\Python37\python.exe'\'' "$@"' > /usr/bin/python \
+    && echo 'wine '\''C:\Python37\Scripts\easy_install.exe'\'' "$@"' > /usr/bin/easy_install \
+    && echo 'wine '\''C:\Python37\Scripts\pip.exe'\'' "$@"' > /usr/bin/pip \
+    && echo 'wine '\''C:\Python37\Scripts\pyinstaller.exe'\'' "$@"' > /usr/bin/pyinstaller \
+    && echo 'wine '\''C:\Python37\Scripts\pyupdater.exe'\'' "$@"' > /usr/bin/pyupdater \
     && echo 'assoc .py=PythonScript' | wine cmd \
-    && echo 'ftype PythonScript=c:\Python36\python.exe "%1" %*' | wine cmd \
+    && echo 'ftype PythonScript=c:\Python37\python.exe "%1" %*' | wine cmd \
     && while pgrep wineserver >/dev/null; do echo "Waiting for wineserver"; sleep 1; done \
     && chmod +x /usr/bin/python /usr/bin/easy_install /usr/bin/pip /usr/bin/pyinstaller /usr/bin/pyupdater \
     && (pip install -U pip || true) \

--- a/win64/py3/Dockerfile
+++ b/win64/py3/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:16.04
 ENV DEBIAN_FRONTEND noninteractive
 
 ARG WINE_VERSION=winehq-staging
-ARG PYTHON_VERSION=3.6.4
+ARG PYTHON_VERSION=3.7.5
 ARG PYINSTALLER_VERSION=3.5
 
 # we need wine for this all to work, so we'll use the PPA
@@ -37,17 +37,17 @@ RUN set -x \
     && winetricks win7 \
     && for msifile in `echo core dev exe lib path pip tcltk tools`; do \
         wget -nv "https://www.python.org/ftp/python/$PYTHON_VERSION/amd64/${msifile}.msi"; \
-        wine msiexec /i "${msifile}.msi" /qb TARGETDIR=C:/Python36; \
+        wine msiexec /i "${msifile}.msi" /qb TARGETDIR=C:/Python37; \
         rm ${msifile}.msi; \
     done \
-    && cd /wine/drive_c/Python36 \
-    && echo 'wine '\''C:\Python36\python.exe'\'' "$@"' > /usr/bin/python \
-    && echo 'wine '\''C:\Python36\Scripts\easy_install.exe'\'' "$@"' > /usr/bin/easy_install \
-    && echo 'wine '\''C:\Python36\Scripts\pip.exe'\'' "$@"' > /usr/bin/pip \
-    && echo 'wine '\''C:\Python36\Scripts\pyinstaller.exe'\'' "$@"' > /usr/bin/pyinstaller \
-    && echo 'wine '\''C:\Python36\Scripts\pyupdater.exe'\'' "$@"' > /usr/bin/pyupdater \
+    && cd /wine/drive_c/Python37 \
+    && echo 'wine '\''C:\Python37\python.exe'\'' "$@"' > /usr/bin/python \
+    && echo 'wine '\''C:\Python37\Scripts\easy_install.exe'\'' "$@"' > /usr/bin/easy_install \
+    && echo 'wine '\''C:\Python37\Scripts\pip.exe'\'' "$@"' > /usr/bin/pip \
+    && echo 'wine '\''C:\Python37\Scripts\pyinstaller.exe'\'' "$@"' > /usr/bin/pyinstaller \
+    && echo 'wine '\''C:\Python37\Scripts\pyupdater.exe'\'' "$@"' > /usr/bin/pyupdater \
     && echo 'assoc .py=PythonScript' | wine cmd \
-    && echo 'ftype PythonScript=c:\Python36\python.exe "%1" %*' | wine cmd \
+    && echo 'ftype PythonScript=c:\Python37\python.exe "%1" %*' | wine cmd \
     && while pgrep wineserver >/dev/null; do echo "Waiting for wineserver"; sleep 1; done \
     && chmod +x /usr/bin/python /usr/bin/easy_install /usr/bin/pip /usr/bin/pyinstaller /usr/bin/pyupdater \
     && (pip install -U pip || true) \


### PR DESCRIPTION
Updated all py3 variants to use Python version 3.7.5 and PyInstaller 3.5. 

Checked Documentation and Python 3.7.5 is compatible with win32. 