### PR TITLE
Add optional UPX

### DIFF
--- a/linux/py2/Dockerfile
+++ b/linux/py2/Dockerfile
@@ -7,7 +7,7 @@ ARG PYINSTALLER_VERSION=3.5
 # install python
 RUN set -x \
     && apt-get update -qy \
-    && apt-get install --no-install-recommends -qfy python python-dev python-pip python-setuptools build-essential libmysqlclient-dev git \
+    && apt-get install --no-install-recommends -qfy python python-dev python-pip python-setuptools build-essential libmysqlclient-dev git upx \
     && apt-get clean
 
 # PYPI repository location

--- a/linux/py3/Dockerfile
+++ b/linux/py3/Dockerfile
@@ -25,6 +25,8 @@ RUN \
         libsqlite3-dev \
         libssl-dev \
         zlib1g-dev \
+        #upx
+        upx \
     # install pyenv
     && echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc \
     && echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc \


### PR DESCRIPTION
Add UPX to both Linux dockerfiles. This allows PyInstaller to use UPX without requiring a more complicated install step.

Solves #73