### PR TITLE
Add more optional dependencies for different submodules

### DIFF
--- a/linux/py2/Dockerfile
+++ b/linux/py2/Dockerfile
@@ -7,7 +7,7 @@ ARG PYINSTALLER_VERSION=3.5
 # install python
 RUN set -x \
     && apt-get update -qy \
-    && apt-get install --no-install-recommends -qfy python python-dev python-pip python-setuptools build-essential libmysqlclient-dev git upx \
+    && apt-get install --no-install-recommends -qfy python python-dev python-pip python-setuptools build-essential libmysqlclient-dev git upx libgdbm-dev libgdbm3 uuid-dev \
     && apt-get clean
 
 # PYPI repository location

--- a/linux/py3/Dockerfile
+++ b/linux/py3/Dockerfile
@@ -25,6 +25,10 @@ RUN \
         libsqlite3-dev \
         libssl-dev \
         zlib1g-dev \
+        #optional libraries
+        libgdbm-dev \
+        libgdbm3 \
+        uuid-dev \
         #upx
         upx \
     # install pyenv


### PR DESCRIPTION
Currently compiling using this container means we miss some optional base modules that require C header files. Adding these to both Linux distributions