### PR TITLE
Python37 support

### DIFF
--- a/linux/py3-32/Dockerfile
+++ b/linux/py3-32/Dockerfile
@@ -1,0 +1,65 @@
+FROM i386/ubuntu:12.04
+SHELL ["/bin/bash", "-i", "-c"]
+
+ARG PYTHON_VERSION=3.7.5
+ARG PYINSTALLER_VERSION=3.5
+
+ENV PYPI_URL=https://pypi.python.org/
+ENV PYPI_INDEX_URL=https://pypi.python.org/simple
+ENV PYENV_VERSION=${PYTHON_VERSION}
+
+COPY entrypoint.sh /entrypoint.sh
+
+RUN \
+    set -x \
+    # update system
+    && apt-get update \
+    # install requirements
+    && apt-get install -y --no-install-recommends \
+        build-essential \
+        ca-certificates \
+        curl \
+        wget \
+        git \
+        libbz2-dev \
+        libreadline-dev \
+        libsqlite3-dev \
+        libssl-dev \
+        zlib1g-dev \
+        libffi-dev \
+        #optional libraries
+        libgdbm-dev \
+        libgdbm3 \
+        uuid-dev \
+        #upx
+        upx \
+    # required because openSSL on Ubuntu 12.04 and 14.04 run out of support versions of OpenSSL
+    && mkdir openssl \
+    && cd openssl \
+    # latest version, there won't be anything newer for this
+    && wget https://www.openssl.org/source/openssl-1.0.2u.tar.gz \
+    && tar -xzvf openssl-1.0.2u.tar.gz \
+    && cd openssl-1.0.2u \
+    && ./Configure linux-generic32 --prefix=$HOME/openssl --openssldir=$HOME/openssl shared zlib \
+    && make \
+    && make install \
+    # install pyenv
+    && echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc \
+    && echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc \
+    && source ~/.bashrc \
+    && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
+    && echo 'eval "$(pyenv init -)"' >> ~/.bashrc \
+    && source ~/.bashrc \
+    # install python
+    && PATH="$HOME/openssl:$PATH"  CPPFLAGS="-O2 -I$HOME/openssl/include" CFLAGS="-I$HOME/openssl/include/" LDFLAGS="-L$HOME/openssl/lib -Wl,-rpath,$HOME/openssl/lib" LD_LIBRARY_PATH=$HOME/openssl/lib:$LD_LIBRARY_PATH LD_RUN_PATH="$HOME/openssl/lib" CONFIGURE_OPTS="--with-openssl=$HOME/openssl" PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install $PYTHON_VERSION \
+    && pyenv global $PYTHON_VERSION \
+    && pip install --upgrade pip \
+    # install pyinstaller
+    && pip install pyinstaller==$PYINSTALLER_VERSION \
+    && mkdir /src/ \
+    && chmod +x /entrypoint.sh
+
+VOLUME /src/
+WORKDIR /src/
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/linux/py3-32/entrypoint.sh
+++ b/linux/py3-32/entrypoint.sh
@@ -1,0 +1,46 @@
+#!/bin/bash -i
+
+# Fail on errors.
+set -e
+
+# Make sure .bashrc is sourced
+. /root/.bashrc
+
+# Allow the workdir to be set using an env var.
+# Useful for CI pipiles which use docker for their build steps
+# and don't allow that much flexibility to mount volumes
+WORKDIR=${SRCDIR:-/src}
+
+#
+# In case the user specified a custom URL for PYPI, then use
+# that one, instead of the default one.
+#
+if [[ "$PYPI_URL" != "https://pypi.python.org/" ]] || \
+   [[ "$PYPI_INDEX_URL" != "https://pypi.python.org/simple" ]]; then
+    # the funky looking regexp just extracts the hostname, excluding port
+    # to be used as a trusted-host.
+    mkdir -p /root/.pip
+    echo "[global]" > /root/.pip/pip.conf
+    echo "index = $PYPI_URL" >> /root/.pip/pip.conf
+    echo "index-url = $PYPI_INDEX_URL" >> /root/.pip/pip.conf
+    echo "trusted-host = $(echo $PYPI_URL | perl -pe 's|^.*?://(.*?)(:.*?)?/.*$|$1|')" >> /root/.pip/pip.conf
+
+    echo "Using custom pip.conf: "
+    cat /root/.pip/pip.conf
+fi
+
+cd $WORKDIR
+
+if [ -f requirements.txt ]; then
+    pip install -r requirements.txt
+fi # [ -f requirements.txt ]
+
+echo "$@"
+
+if [[ "$@" == "" ]]; then
+    pyinstaller --clean -y --dist ./dist/linux --workpath /tmp *.spec
+    chown -R --reference=. ./dist/linux
+else
+    sh -c "$@"
+fi # [[ "$@" == "" ]]
+

--- a/linux/py3-64/Dockerfile
+++ b/linux/py3-64/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:12.04
+FROM amd64/ubuntu:12.04
 SHELL ["/bin/bash", "-i", "-c"]
 
 ARG PYTHON_VERSION=3.7.5


### PR DESCRIPTION
Add support for Ubuntu 12.04 32b Python 3.7 support.

Tested the basic stuff (hello world, booting the Infection Monkey).

