### PR TITLE
Feature/63 multiple spec files

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,14 @@ Replace `wget` with the dependencies / package(s) you need to install.
 
 will generate a `spec` file for `your-script.py` in your current working directory. See the PyInstaller docs for more information.
 
+##### How do I specify one of many preexisting .spec files?
+
+If you have multiple `spec` files in your source directory, you might want to specify which one to use.
+
+`docker run -v "$(pwd):/src/" cdrx/pyinstaller-linux "pyinstaller --clean -y --dist ./dist/linux --workpath /tmp your-spec.spec && chown -R --reference=. ./dist/linux"`
+
+will generate a binary for `your-spec.spec` only.
+
 ##### How do I change the PyInstaller version used?
 
 Add `pyinstaller=3.1.1` to your `requirements.txt`.

--- a/entrypoint-linux.sh
+++ b/entrypoint-linux.sh
@@ -38,7 +38,11 @@ fi # [ -f requirements.txt ]
 echo "$@"
 
 if [[ "$@" == "" ]]; then
-    pyinstaller --clean -y --dist ./dist/linux --workpath /tmp *.spec
+    SPECS=($(ls *.spec))
+    for NEXT in ${SPECS[@]}; do
+        echo "Located pyinstaller spec file: $NEXT"
+        pyinstaller --clean -y --dist ./dist/linux --workpath /tmp $NEXT
+    done
     chown -R --reference=. ./dist/linux
 else
     sh -c "$@"

--- a/entrypoint-windows.sh
+++ b/entrypoint-windows.sh
@@ -38,7 +38,11 @@ fi # [ -f requirements.txt ]
 echo "$@"
 
 if [[ "$@" == "" ]]; then
-    pyinstaller --clean -y --dist ./dist/windows --workpath /tmp *.spec
+    SPECS=($(ls *.spec))
+    for NEXT in ${SPECS[@]}; do
+        echo "Located pyinstaller spec file: $NEXT"
+        pyinstaller --clean -y --dist ./dist/windows --workpath /tmp $NEXT
+    done
     chown -R --reference=. ./dist/windows
 else
     sh -c "$@"


### PR DESCRIPTION
Addressing issue #63:

- Entrypoint script modified to iterate over `.spec` files in `src/` . Without this the wildcard `*.spec` was interpreted as any (i.e. one at random).
- Added instructions how to generate a dedicated `.spec` file with README.md