### PR TITLE
Bump Ubuntu, PyInstaller and Python versions and required fixes

### DIFF
--- a/Dockerfile-py3-win64
+++ b/Dockerfile-py3-win64
@@ -1,16 +1,16 @@
-FROM ubuntu:16.04
+FROM ubuntu:20.04
 
 ENV DEBIAN_FRONTEND noninteractive
 
 ARG WINE_VERSION=winehq-staging
-ARG PYTHON_VERSION=3.7.5
-ARG PYINSTALLER_VERSION=3.6
+ARG PYTHON_VERSION=3.8.5
+ARG PYINSTALLER_VERSION=4.0
 
 # we need wine for this all to work, so we'll use the PPA
 RUN set -x \
     && dpkg --add-architecture i386 \
     && apt-get update -qy \
-    && apt-get install --no-install-recommends -qfy apt-transport-https software-properties-common wget \
+    && apt-get install --no-install-recommends -qfy apt-transport-https software-properties-common wget gpg-agent rename \
     && wget -nv https://dl.winehq.org/wine-builds/winehq.key \
     && apt-key add winehq.key \
     && add-apt-repository 'https://dl.winehq.org/wine-builds/ubuntu/' \
@@ -37,20 +37,20 @@ RUN set -x \
     && winetricks win7 \
     && for msifile in `echo core dev exe lib path pip tcltk tools`; do \
         wget -nv "https://www.python.org/ftp/python/$PYTHON_VERSION/amd64/${msifile}.msi"; \
-        wine msiexec /i "${msifile}.msi" /qb TARGETDIR=C:/Python37; \
+        wine msiexec /i "${msifile}.msi" /qb TARGETDIR=C:/Python38; \
         rm ${msifile}.msi; \
     done \
-    && cd /wine/drive_c/Python37 \
-    && echo 'wine '\''C:\Python37\python.exe'\'' "$@"' > /usr/bin/python \
-    && echo 'wine '\''C:\Python37\Scripts\easy_install.exe'\'' "$@"' > /usr/bin/easy_install \
-    && echo 'wine '\''C:\Python37\Scripts\pip.exe'\'' "$@"' > /usr/bin/pip \
-    && echo 'wine '\''C:\Python37\Scripts\pyinstaller.exe'\'' "$@"' > /usr/bin/pyinstaller \
-    && echo 'wine '\''C:\Python37\Scripts\pyupdater.exe'\'' "$@"' > /usr/bin/pyupdater \
+    && cd /wine/drive_c/Python38 \
+    && echo 'wine '\''C:\Python38\python.exe'\'' "$@"' > /usr/bin/python \
+    && echo 'wine '\''C:\Python38\Scripts\easy_install.exe'\'' "$@"' > /usr/bin/easy_install \
+    && echo 'wine '\''C:\Python38\Scripts\pip.exe'\'' "$@"' > /usr/bin/pip \
+    && echo 'wine '\''C:\Python38\Scripts\pyinstaller.exe'\'' "$@"' > /usr/bin/pyinstaller \
+    && echo 'wine '\''C:\Python38\Scripts\pyupdater.exe'\'' "$@"' > /usr/bin/pyupdater \
     && echo 'assoc .py=PythonScript' | wine cmd \
     && echo 'ftype PythonScript=c:\Python37\python.exe "%1" %*' | wine cmd \
     && while pgrep wineserver >/dev/null; do echo "Waiting for wineserver"; sleep 1; done \
     && chmod +x /usr/bin/python /usr/bin/easy_install /usr/bin/pip /usr/bin/pyinstaller /usr/bin/pyupdater \
-    && (pip install -U pip || true) \
+    && (pip install --user -U pip || true) \
     && rm -rf /tmp/.wine-*
 
 ENV W_DRIVE_C=/wine/drive_c


### PR DESCRIPTION
I have bumped the version numbers of Ubuntu, Python and PyInstaller. Not sure if this can be pushed to the `python3` label or warrants a new `python3.8` label perhaps. If these changes are okay, I can update `Dockerfile-py3-i386` as well.